### PR TITLE
fix: faq url

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -19,7 +19,7 @@ If you have any more questions, don't hesitate to ask in the [Discord server](ht
 
 ## Others
 
-- [FAQ](/docs/FAQ)
+- [FAQ](/docs/faq)
 - [S3 Storage](/docs/storage)
 - [SSO - Keycloak](/docs/keycloak)
 - 🆕 [Local storage](/docs/local-storage)


### PR DESCRIPTION
uppercase FAQ returns 404, lowercase works. this is a workaround, capitals should probably be ignored/redirected