### PR TITLE
docs: fix link address

### DIFF
--- a/content/docs/install/index.md
+++ b/content/docs/install/index.md
@@ -4,4 +4,4 @@ title: Installation
 
 > memos is designed to be self-hosted with Docker and you can run it on any server with Docker installed.
 
-- [Self-Hosted](/docs/install/self-hosted)
+- [Self-Hosted](/docs/install/self-hosting)

--- a/content/docs/install/index.md
+++ b/content/docs/install/index.md
@@ -4,4 +4,4 @@ title: Installation
 
 > memos is designed to be self-hosted with Docker and you can run it on any server with Docker installed.
 
-- [Self-Hosted](/docs/install/self-hosting)
+- [Self-Hosting](/docs/install/self-hosting)


### PR DESCRIPTION
Updated "Self-Hosted" link address to match target page name of "Self-Hosting"