### PR TITLE
docs: add document on metrics collection

### DIFF
--- a/content/docs/advanced-settings/metrics.md
+++ b/content/docs/advanced-settings/metrics.md
@@ -10,7 +10,7 @@ By default, Memos collects anonymized metrics using [PostHog](https://posthog.co
 - Resource Creation
 - User Creation
 
-If you wish to opt out of metrics collections, add the `--metrics=false` flag to your Docker command like so:
+If you wish to opt out of metrics collections, add the `--metric=false` flag to your Docker command like so:
 
 ```shell
 docker run -d --name memos -p 5230:5230 -v ~/.memos/:/var/opt/memos ghcr.io/usememos/memos:latest --metric=false

--- a/content/docs/advanced-settings/metrics.md
+++ b/content/docs/advanced-settings/metrics.md
@@ -1,0 +1,17 @@
+---
+title: Metrics
+---
+
+By default, Memos collects anonymized metrics using [PostHog](https://posthog.com/). These metrics are triggered during the following events:
+- Server Start
+- Memo Creation
+- Memo Comment Creation
+- Webhook Dispatch
+- Resource Creation
+- User Creation
+
+If you wish to opt out of metrics collections, add the `--metrics=false` flag to your Docker command like so:
+
+```shell
+docker run -d --name memos -p 5230:5230 -v ~/.memos/:/var/opt/memos ghcr.io/usememos/memos:latest --metric=false
+```

--- a/src/app/docs/[[...slug]]/navigation.tsx
+++ b/src/app/docs/[[...slug]]/navigation.tsx
@@ -76,6 +76,10 @@ const DOCS_NODES: DocsNode[] = [
         text: "SEO",
         link: "/docs/advanced-settings/seo",
       },
+      {
+        text: "Metrics",
+        link: "/docs/advanced-settings/metrics",
+      },
     ],
   },
   {


### PR DESCRIPTION
Based on this [closed issue](https://github.com/usememos/memos/issues/934), Memos should be more transparent on Metrics collection and how to opt out of it.