### PR TITLE
docs: add Instruction to Opt out of Metrics in Docker Compose

### DIFF
--- a/content/docs/advanced-settings/metrics.md
+++ b/content/docs/advanced-settings/metrics.md
@@ -16,3 +16,18 @@ If you wish to opt out of metrics collections, add the `--metric=false` flag to 
 ```shell
 docker run -d --name memos -p 5230:5230 -v ~/.memos/:/var/opt/memos neosmemo/memos:stable --metric=false
 ```
+
+For Docker Compose, you can use `command` in your compose file:
+
+```diff
+version: "3.0"
+services:
+  memos:
+    image: neosmemo/memos:stable
+    container_name: memos
++   command: --metric=false 
+    volumes:
+      - ./memos/:/var/opt/memos
+    ports:
+      - 5230:5230
+```


### PR DESCRIPTION
The instruction, for opting out of metrics, lacks an example for docker compose. So I just added it. 

Please take a look into it, thanks! 