### PR TITLE
feat: improve markdoc tags/nodes

### DIFF
--- a/src/components/Admonition.tsx
+++ b/src/components/Admonition.tsx
@@ -1,0 +1,55 @@
+import classnames from "classnames";
+import type React from "react";
+import Icon from "./Icon";
+
+const icons = {
+  note: Icon.InfoIcon,
+  tip: Icon.Lightbulb,
+  important: Icon.MessageSquareWarning,
+  warning: Icon.TriangleAlert,
+  caution: Icon.AlertOctagon,
+};
+export const admonitionTones = Object.keys(icons);
+
+export interface AdmonitionProps {
+  title: string;
+  icon?: keyof typeof icons;
+  children: React.ReactNode;
+}
+
+export function Admonition({ title, icon = "note", children }: AdmonitionProps) {
+  const Icon = icons[icon] || icons.note;
+
+  const borderColor = {
+    "border-sky-500": icon === "note",
+    "border-green-500": icon === "tip",
+    "border-violet-500": icon === "important",
+    "border-amber-400": icon === "warning",
+    "border-red-600": icon === "caution",
+  };
+
+  const iconColor = {
+    "text-sky-500": icon === "note",
+    "text-green-500": icon === "tip",
+    "text-violet-500": icon === "important",
+    "text-amber-400": icon === "warning",
+    "text-red-600": icon === "caution",
+  };
+
+  const iconMargin = title ? "mt-0.5" : "mt-2";
+  return (
+    <div className={classnames("border-l-[.8vh] border-r-[.3vh] pl-4 pt-2  m-1", borderColor)}>
+      <div className="flex">
+        <div className={classnames("flex-shrink-0", iconMargin)}>
+          <Icon className={classnames("w-5 h-5", iconColor)} />
+        </div>
+        <div className="ml-3">
+          <span className={classnames("font-semibold", iconColor)}>{title}</span>
+          <div className="mt-[1vh] text-sm text-slate-700">
+            <span className="flex flex-col space-y-2">{children}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ContentRender.tsx
+++ b/src/components/ContentRender.tsx
@@ -1,7 +1,8 @@
-import Markdoc, { RenderableTreeNode } from "@markdoc/markdoc";
+import Markdoc, { type RenderableTreeNode } from "@markdoc/markdoc";
 import classNames from "classnames";
 import "github-markdown-css/github-markdown-light.css";
 import React from "react";
+import { components } from "@/markdoc/markdoc";
 import "@/styles/typography.css";
 
 interface Props {
@@ -17,7 +18,7 @@ const ContentRender = ({ markdocNode, className }: Props) => {
         className,
       )}
     >
-      {Markdoc.renderers.react(markdocNode, React)}
+      {Markdoc.renderers.react(markdocNode, React, { components })}
     </div>
   );
 };

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,0 +1,32 @@
+import classnames from "classnames";
+import type { ReactNode, JSX } from "react";
+import Icon from "./Icon";
+
+interface Props {
+  id: string;
+  level: number;
+  children: ReactNode;
+  className: string;
+}
+
+export function Heading({ id = "", level = 1, children, className }: Props) {
+  const textSize = {
+    "text-3xl": level === 1,
+    "text-2xl": level === 2,
+    "text-xl": level === 3,
+    "text-lg": level === 4,
+    "text-base": level === 5,
+    "text-sm": level === 6,
+  };
+
+  const Component = `h${level}` as keyof JSX.IntrinsicElements;
+
+  return (
+    <Component id={id} className={["not-prose group", className].filter(Boolean).join(" ")}>
+      {children}
+      <a href={`#${id}`}>
+        <Icon.Hash className={classnames("w-4 h-4 ml-2 mb-1 inline opacity-0 group-hover:opacity-100 text-slate-400", textSize)} />
+      </a>
+    </Component>
+  );
+}

--- a/src/markdoc/admonition.ts
+++ b/src/markdoc/admonition.ts
@@ -1,0 +1,22 @@
+import type { Schema } from "@markdoc/markdoc";
+import { admonitionTones } from "../components/Admonition";
+
+const admonition: Schema = {
+  render: "Admonition",
+  description: "Display the enclosed content in an admonition block",
+  children: ["paragraph", "tag", "list", "link"],
+  attributes: {
+    icon: {
+      type: String,
+      default: "note",
+      matches: admonitionTones,
+      description: 'Controls the color and icon of the admonition. Can be: "note", "tip", "important", "warning", "caution"',
+    },
+    title: {
+      type: String,
+      description: "The title displayed at the top of the admonition",
+    },
+  },
+};
+
+export default admonition;

--- a/src/markdoc/admonition.ts
+++ b/src/markdoc/admonition.ts
@@ -1,7 +1,7 @@
 import type { Schema } from "@markdoc/markdoc";
-import { admonitionTones } from "../components/Admonition";
+import { admonitionTones } from "@/components/Admonition";
 
-const admonition: Schema = {
+const admonitionSchema: Schema = {
   render: "Admonition",
   description: "Display the enclosed content in an admonition block",
   children: ["paragraph", "tag", "list", "link"],
@@ -19,4 +19,4 @@ const admonition: Schema = {
   },
 };
 
-export default admonition;
+export default admonitionSchema;

--- a/src/markdoc/heading.ts
+++ b/src/markdoc/heading.ts
@@ -1,11 +1,14 @@
-import { nodes } from "@markdoc/markdoc";
+import { Tag, type nodes } from "@markdoc/markdoc";
+import type { Node, RenderableTreeNode, Schema } from "@markdoc/markdoc";
 
-const generateID = (children: any, attributes: any) => {
-  if (attributes.id && typeof attributes.id === "string") {
+type Attributes = Readonly<Partial<typeof nodes.heading.attributes>>;
+
+const generateID = (children: RenderableTreeNode[], attributes: Attributes) => {
+  if (attributes?.id && typeof attributes.id === "string") {
     return attributes.id;
   }
   return children
-    .filter((child: any) => typeof child === "string")
+    .filter((child: RenderableTreeNode) => typeof child === "string")
     .join(" ")
     .replace(/[?]/g, "")
     .replace(/\./g, "")
@@ -13,13 +16,21 @@ const generateID = (children: any, attributes: any) => {
     .toLowerCase();
 };
 
-const header = {
-  ...nodes.heading,
-  transform(node: any, config: any) {
-    const base = (nodes as any).heading.transform(node, config);
-    base.attributes.id = generateID(base.children, base.attributes);
-    return base;
+const headingSchema = {
+  render: "Heading",
+  children: ["inline"],
+  attributes: {
+    id: { type: "String" },
+    level: { type: "Number", required: true, default: 1 },
+    className: { type: "String" },
+  },
+  transform(node: Node, config: Attributes) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config || {});
+    const id = generateID(children, attributes);
+
+    return new Tag(this.render, { ...attributes, id }, children);
   },
 };
 
-export default header;
+export default headingSchema as Schema;

--- a/src/markdoc/markdoc.ts
+++ b/src/markdoc/markdoc.ts
@@ -1,11 +1,15 @@
 import Markdoc from "@markdoc/markdoc";
+import type { Config } from "@markdoc/markdoc";
 import yaml from "js-yaml";
-import { Frontmatter } from "@/types/content";
+import type { Frontmatter } from "@/types/content";
+import admonition from "./admonition";
 import heading from "./heading";
 
 export const markdoc = (content: string) => {
-  const config = {
-    tags: {},
+  const config: Config = {
+    tags: {
+      admonition: admonition,
+    },
     nodes: {
       heading,
     },

--- a/src/markdoc/markdoc.ts
+++ b/src/markdoc/markdoc.ts
@@ -1,17 +1,23 @@
-import Markdoc from "@markdoc/markdoc";
-import type { Config } from "@markdoc/markdoc";
+import Markdoc, { type Config } from "@markdoc/markdoc";
 import yaml from "js-yaml";
+import { Admonition } from "@/components/Admonition";
+import { Heading } from "@/components/Heading";
 import type { Frontmatter } from "@/types/content";
-import admonition from "./admonition";
-import heading from "./heading";
+import admonitionSchema from "./admonition";
+import headingSchema from "./heading";
+
+export const components = {
+  Admonition: Admonition,
+  Heading: Heading,
+};
 
 export const markdoc = (content: string) => {
   const config: Config = {
     tags: {
-      admonition: admonition,
+      admonition: admonitionSchema,
     },
     nodes: {
-      heading,
+      heading: headingSchema,
     },
     variables: {},
   };


### PR DESCRIPTION
feat: add admonition (call-out) tag

- Naming based on [GitHub implementation](https://github.com/orgs/community/discussions/16925)

```md
{% admonition icon="note" title="Note" %}
Highlights information that users should take into account, even when skimming.
{% /admonition %}

{% admonition icon="tip" title="Tip" %}
Optional information to help a user be more successful.
{% /admonition %}

{% admonition icon="important" title="Important" %}
Crucial information necessary for users to succeed.
{% /admonition %}

{% admonition icon="warning" title="Warning"%}
Critical content demanding immediate user attention due to potential risks.
{% /admonition %}

{% admonition icon="caution" title="Caution" %}
Negative potential consequences of an action.
{% /admonition %}
```

![Captura de tela de 2024-06-06 18-19-30](https://github.com/usememos/dotcom/assets/7476810/52c4e6c5-f7f0-4c57-8d0e-91c9d0bcb89e)

feat: improve headings

- handle different heading sizes
- show direct link icon on hover

![Captura de tela de 2024-06-08 08-37-17](https://github.com/usememos/dotcom/assets/7476810/0183ef9c-0530-4ebf-bce4-edc405ce5098)
