### PR TITLE
chore: cleanup faq

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -2,22 +2,8 @@
 title: Frequently Asked Questions
 ---
 
-- [How to delete old tags](#how-to-delete-old-tags)
-- [How to change the created time of a memo](#how-to-change-the-created-time-of-a-memo)
-- [How to upload videos in Memos](#how-to-upload-videos-in-memos)
-
-## How to delete old tags
-
-click the "+" button -> hover and click the tag you want to delete.
-
-![how-to-delete-tags-img](https://media.discordapp.net/attachments/1045138348165050409/1097050919398547496/image.png?width=1342&height=725)
-
-## How to change the created time of a memo
+## Change the created time of a memo
 
 `ALT` + click the datetime of a memo on the top left corner.
 
 ![change-created-time-of-memo](/content/docs/faq/change-created-time-of-memo.png)
-
-## How to upload videos in Memos
-
-You can upload videos up to 32 MB in size. In addition, the video must be compatible with HTML5. See more in [https://www.chromium.org/audio-video/](https://www.chromium.org/audio-video/)

--- a/content/docs/getting-started/resources.md
+++ b/content/docs/getting-started/resources.md
@@ -25,3 +25,12 @@ Resources are seamlessly integrated into Memos, making it easy to access and ref
 Resources within Memos offer an effective way to manage and reference non-textual content, enriching your knowledge management system. By combining multimedia content with textual notes and efficiently organizing resources, you can unlock new dimensions of understanding and creativity.
 
 Start attaching images, videos, and more to your Memos today and experience the benefits of a truly multimedia knowledge management system.
+
+## Uploading video and audio files to Memos
+
+By default, you can upload resources up to 30 MB in size. You can increase this limit by going to storage settings and changing "maximum upload size" to a higher value.
+
+{% admonition icon="important" %}
+Uploaded video and audio files must be HTML5 compatible for proper playback; otherwise, you will see a black screen.
+For more information, refer to the [Chromium Browser Project](https://www.chromium.org/audio-video/).
+{% /admonition %}

--- a/content/docs/getting-started/tags.md
+++ b/content/docs/getting-started/tags.md
@@ -36,6 +36,18 @@ Tags in Memos serve various purposes, including:
 
 In your memo's content, use the format `#tag` and add a space after the tag name. For example, type `#programming/java` and then press the spacebar.
 
+## Renaming Tags
+
+- Find the Tags section on the right sidebar.
+- Hover over the **#** sign next to the tag, it will change to **⁝** .
+- Click on the menu button and then choose "**Rename**".
+
+## Deleting Tags
+
+- Find the Tags section on the right sidebar.
+- Hover over the **#** sign next to the tag, it will change to **⁝** .
+- Click on the menu button and then choose "**Delete**".
+
 ---
 
 **Read more**


### PR DESCRIPTION

Alt + click to edit a Memo date is not working anymore. I'm not sure if the feature is broken or if it was retired. If the latter is the case, the FAQ section can be removed completely.