### PR TITLE
docs: table syntax to add space for table headers

### DIFF
--- a/content/docs/getting-started/content-syntax.md
+++ b/content/docs/getting-started/content-syntax.md
@@ -152,7 +152,7 @@ $$
 
 ### Tables
 
-To add a table, use three or more hyphens (---) to create each column’s header, and use pipes (|) to separate each column. For compatibility, you should also add a pipe on either end of the row.
+To add a table, use three or more hyphens (---) to create each column’s header, and use pipes (|) to separate each column. For compatibility, you should also add a pipe on either end of the row, and make sure to add a space between the pipe and the hyphens.
 
 ```markdown
 | Syntax    | Description |


### PR DESCRIPTION
This PR adds a little bit of information to Memo on using the table syntax.
Currently this syntax is not rendered properly unless there's space between the
hypens and pipes.


```md
| Heading 1 | Heading 2 |
|-----------|-----------|
| Content 1 | Content 2 |
```

**Preview:**

![Screenshot from 2025-01-27 22-17-19](https://github.com/user-attachments/assets/916298b9-f22a-4bb9-8873-b26c2bb83bf9)


---
However, with space, this works properly.

```md
| Heading 1 | Heading 2 |
| ----------- | ----------- |
| Content 1 | Content 2 |
```

**Preview:**

![Screenshot from 2025-01-27 22-18-31](https://github.com/user-attachments/assets/32f0670b-a001-4a07-bfae-c27b17a60e95)

In Github, both syntax works, so I think it's better to add more information to
the documentation.
