### PR TITLE
fix: remove enclosure tag from RSS feed to fix validation errors

### DIFF
--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -41,7 +41,6 @@ export async function GET() {
       <guid isPermaLink="true">${postUrl}</guid>
       <pubDate>${pubDate}</pubDate>
       <description>${escapeXml(post.data.description || "")}</description>
-      ${post.data.feature_image ? `<enclosure url="${post.data.feature_image.startsWith("http") ? post.data.feature_image : `${BASE_URL}${post.data.feature_image}`}" type="image/jpeg" />` : ""}
       ${post.data.tags ? post.data.tags.map((tag) => `<category>${escapeXml(tag)}</category>`).join("\n      ") : ""}
     </item>`;
       })


### PR DESCRIPTION
The RSS 2.0 spec requires the 'length' attribute on enclosure tags, but we cannot easily determine file sizes at build time. Removing enclosures since feature images are already available through OpenGraph metadata and blog post HTML content.