### PR TITLE
refactor(scratch): rename canvas to workspace

### DIFF
--- a/src/app/scratch/page.tsx
+++ b/src/app/scratch/page.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { TrashIcon, SettingsIcon, SaveIcon, HomeIcon, SunIcon, MoonIcon, MonitorIcon } from "lucide-react";
 import { InstanceSetupForm } from "@/components/scratch/instance-setup-form";
-import { Canvas } from "@/components/scratch/canvas";
+import { Workspace } from "@/components/scratch/workspace";
 import type { ScratchpadItem, MemoInstance } from "@/lib/scratch/types";
 import { itemStorage, instanceStorage } from "@/lib/scratch/storage";
 import { saveFile, createFileData, getFile, deleteFile } from "@/lib/scratch/indexeddb";
@@ -418,9 +418,9 @@ export default function ScratchPage() {
       </div>
       <input ref={fileInputRef} type="file" multiple onChange={handleFileInputChange} className="hidden" />
 
-      {/* Canvas - Full Screen */}
+      {/* Workspace - Full Screen */}
       <div className="h-screen">
-        <Canvas
+        <Workspace
           items={items}
           onUpdateItem={handleUpdateItem}
           onDeleteItem={handleDeleteItem}


### PR DESCRIPTION
…rmance

The scratch page doesn't use HTML canvas - it uses simple divs with position calculations. This commit addresses naming clarity and drag performance:

- Renamed canvas.tsx to workspace.tsx for accurate naming
- Updated all references (CanvasProps -> WorkspaceProps, canvasRef -> workspaceRef)
- Optimized drag-and-move with requestAnimationFrame for smoother performance
- Added drag state refs to avoid unnecessary re-renders during drag operations
- Throttled position updates during drag for streamlined user experience

The drag implementation now uses RAF to batch updates and only commits the final position on mouse up, resulting in much smoother dragging.