### PR TITLE
docs: update build and run commands in development docs

### DIFF
--- a/content/docs/installation/development.mdx
+++ b/content/docs/installation/development.mdx
@@ -132,10 +132,10 @@ EOF
 
 ```bash
 # Build backend
-make build
+./scripts/build.sh
 
 # Run development server
-./memos
+./build/memos --mode dev
 ```
 
 #### Hot Reloading with Air


### PR DESCRIPTION
Updates the build and run commands in development docs. Previously, the build command was `make build` which is wrong since there is no Makefile. 

Resolves usememos/memos#5303