### PR TITLE
feat(typography): add serif display styling to marketing headings

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -99,7 +99,7 @@ export default function HomePage() {
             <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
               <StarIcon className="w-7 h-7 sm:w-8 sm:h-8" />
             </div>
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight text-balance px-2">
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight text-balance px-2">
               Why Memos?
             </h2>
             <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-3xl mx-auto px-4">
@@ -166,7 +166,7 @@ export default function HomePage() {
             <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
               <LightbulbIcon className="w-7 h-7 sm:w-8 sm:h-8" />
             </div>
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight">
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight">
               Who Uses Memos?
             </h2>
             <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
@@ -258,7 +258,7 @@ export default function HomePage() {
             <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-tr from-cyan-400/20 to-teal-400/20 dark:from-cyan-600/10 dark:to-teal-600/10 rounded-full blur-3xl"></div>
             <div className="relative z-10">
               <div className="text-center mb-8 sm:mb-12">
-                <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+                <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">
                   Built Together, in the Open
                 </h2>
                 <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
@@ -303,7 +303,7 @@ export default function HomePage() {
             <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
               <RocketIcon className="w-7 h-7 sm:w-8 sm:h-8" />
             </div>
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight">
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 leading-tight">
               One Command. Running in Minutes.
             </h2>
             <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
@@ -342,7 +342,7 @@ export default function HomePage() {
                 <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
                   <NotebookIcon className="w-7 h-7 sm:w-9 sm:h-9" />
                 </div>
-                <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4 leading-tight">
+                <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4 leading-tight">
                   Type. Save. Done.
                 </h2>
                 <p className="text-base sm:text-lg text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
@@ -422,7 +422,7 @@ export default function HomePage() {
           <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
             <BirdIcon className="w-7 h-7 sm:w-8 sm:h-8" />
           </div>
-          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight px-2">
+          <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight px-2">
             Your Thoughts. Your Server. Your Rules.
           </h2>
           <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300 mb-8 sm:mb-10 max-w-2xl mx-auto leading-relaxed px-4">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -89,7 +89,7 @@ export default async function BlogPostPage({ params }: BlogPageProps) {
 
             {/* Article Header */}
             <header className="px-2 sm:px-0">
-              <h1 className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl 2xl:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 leading-tight">
+              <h1 className="font-serif text-2xl sm:text-3xl lg:text-4xl xl:text-5xl 2xl:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 leading-tight">
                 {data.title}
               </h1>
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -46,7 +46,9 @@ export default function BlogPage() {
           <div className="max-w-4xl mx-auto">
             {/* Hero Section */}
             <div className="mb-12 sm:mb-16 lg:mb-20">
-              <h1 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight">Blogs</h1>
+              <h1 className="font-serif text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight">
+                Blogs
+              </h1>
               <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 leading-relaxed">
                 Insights, updates, and stories from the team building Memos.
               </p>
@@ -62,7 +64,7 @@ export default function BlogPage() {
                   <Link href={post.url} className="block">
                     {/* Content */}
                     <div>
-                      <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3 sm:mb-4 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors tracking-tight">
+                      <h2 className="font-serif text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3 sm:mb-4 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors tracking-tight">
                         {post.data.title}
                       </h2>
 

--- a/src/app/brand/page.tsx
+++ b/src/app/brand/page.tsx
@@ -68,7 +68,7 @@ export default function BrandPage() {
                   <PaletteIcon className="w-7 h-7 sm:w-8 sm:h-8" />
                 </div>
               </div>
-              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl mb-4 sm:mb-6 leading-tight">Brand</h1>
+              <h1 className="font-serif text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl mb-4 sm:mb-6 leading-tight">Brand</h1>
               <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed">
                 Download official Memos brand assets and use them with clear, consistent presentation.
               </p>
@@ -76,7 +76,7 @@ export default function BrandPage() {
 
             {/* Primary Logos */}
             <section className="mb-12 sm:mb-16">
-              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Primary Logos</h2>
+              <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Primary Logos</h2>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                 {LOGO_ASSETS.map((logo) => (
                   <div
@@ -104,7 +104,7 @@ export default function BrandPage() {
 
             {/* Full Logos */}
             <section className="mb-12 sm:mb-16">
-              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Full Logos</h2>
+              <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Full Logos</h2>
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6">
                 {FULL_LOGOS.map((logo) => (
                   <div
@@ -132,7 +132,7 @@ export default function BrandPage() {
 
             {/* Guidelines */}
             <section className="mb-12 sm:mb-16">
-              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Guidelines</h2>
+              <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Guidelines</h2>
               <div className="bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-2xl p-6 sm:p-8">
                 <ul className="space-y-4">
                   {GUIDELINES.map((guideline) => (
@@ -147,7 +147,7 @@ export default function BrandPage() {
 
             {/* Usage & Attribution */}
             <section className="mb-12 sm:mb-16">
-              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Usage</h2>
+              <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-8 text-center">Usage</h2>
               <div className="bg-gradient-to-br from-teal-50 to-cyan-50 dark:from-teal-950 dark:to-cyan-950 border border-teal-200 dark:border-teal-800 rounded-2xl p-6 sm:p-8">
                 <p className="text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
                   Memos is open source. You are welcome to use our brand assets in ways that stay clear, respectful, and consistent:
@@ -178,7 +178,9 @@ export default function BrandPage() {
             {/* Contact CTA */}
             <section className="text-center">
               <div className="bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 dark:from-teal-950 dark:via-cyan-950 dark:to-blue-950 border border-teal-200 dark:border-teal-800 rounded-2xl sm:rounded-3xl p-6 sm:p-8 lg:p-12 shadow-lg">
-                <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-teal-900 dark:text-teal-100 mb-3 sm:mb-4">Questions?</h2>
+                <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-teal-900 dark:text-teal-100 mb-3 sm:mb-4">
+                  Questions?
+                </h2>
                 <p className="text-base sm:text-lg text-teal-800 dark:text-teal-200 mb-6 sm:mb-8 max-w-xl mx-auto leading-relaxed">
                   Need special permissions or have questions about brand usage?
                 </p>

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -59,7 +59,7 @@ export default function ChangelogPage() {
           <div className="max-w-4xl mx-auto">
             {/* Hero Section */}
             <div className="mb-12 sm:mb-16 lg:mb-20">
-              <h1 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight">
+              <h1 className="font-serif text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight">
                 Changelogs
               </h1>
               <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -93,7 +93,7 @@ export default function ChangelogPage() {
                       {/* Header */}
                       <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
                         <div>
-                          <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors">
+                          <h2 className="font-serif text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors">
                             {version}
                           </h2>
                           {entry.data.date && (

--- a/src/app/features/[slug]/page.tsx
+++ b/src/app/features/[slug]/page.tsx
@@ -29,7 +29,7 @@ export default async function FeaturePage({ params }: FeaturePageProps) {
         <section className="relative py-16 sm:py-20 lg:py-32 px-4 sm:px-6 overflow-hidden bg-gradient-to-br from-white via-gray-50/50 to-teal-50/30 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700">
           <div className="absolute inset-0 bg-grid-gray-100/50 dark:bg-grid-gray-800/50 [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)] pointer-events-none"></div>
           <div className="relative max-w-5xl mx-auto text-center">
-            <h1 className="text-3xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold tracking-tight mb-4 sm:mb-6 leading-[1.1] text-balance text-gray-900 dark:text-gray-50">
+            <h1 className="font-serif text-3xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold tracking-tight mb-4 sm:mb-6 leading-[1.1] text-balance text-gray-900 dark:text-gray-50">
               {feature.hero.title}
             </h1>
             <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed mb-8 sm:mb-10 lg:mb-12 text-balance px-4">
@@ -58,7 +58,7 @@ export default async function FeaturePage({ params }: FeaturePageProps) {
         {/* Benefits Section */}
         <section className="py-12 sm:py-16 lg:py-24 px-4 sm:px-6">
           <div className="max-w-5xl mx-auto">
-            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
+            <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
               Key Benefits
             </h2>
             <div className="grid grid-cols-1 gap-3 sm:gap-4">
@@ -80,7 +80,7 @@ export default async function FeaturePage({ params }: FeaturePageProps) {
         {/* Use Cases Section */}
         <section className="py-12 sm:py-16 lg:py-24 px-4 sm:px-6 bg-gradient-to-b from-gray-50/80 to-white dark:from-gray-800 dark:to-gray-900">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
+            <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
               Works Well For
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 lg:gap-8">
@@ -105,7 +105,7 @@ export default async function FeaturePage({ params }: FeaturePageProps) {
         {/* Technical Details Section */}
         <section className="py-12 sm:py-16 lg:py-24 px-4 sm:px-6">
           <div className="max-w-5xl mx-auto">
-            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
+            <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 lg:mb-12 text-center">
               Technical Details
             </h2>
             <div className="relative bg-gradient-to-br from-teal-50/80 via-cyan-50/50 to-gray-50 dark:from-gray-800 dark:via-gray-800 dark:to-gray-700 border border-teal-100 dark:border-gray-700 rounded-2xl sm:rounded-3xl p-6 sm:p-8 lg:p-10 shadow-lg">
@@ -126,7 +126,7 @@ export default async function FeaturePage({ params }: FeaturePageProps) {
         <section className="relative py-16 sm:py-20 lg:py-32 px-4 sm:px-6 overflow-hidden bg-gradient-to-br from-gray-50 via-white to-teal-50/30 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700">
           <div className="absolute inset-0 bg-grid-gray-100/50 dark:bg-grid-gray-800/50 [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)] pointer-events-none"></div>
           <div className="relative max-w-4xl mx-auto text-center">
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight text-balance">
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight text-balance">
               Ready to Get Started?
             </h2>
             <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 mb-8 sm:mb-10 max-w-2xl mx-auto leading-relaxed text-balance px-4">

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -54,7 +54,7 @@ export default function FeaturesPage() {
         {/* Hero Section */}
         <section className="py-24 px-4 bg-gradient-to-b from-white to-gray-50/50 dark:from-gray-900 dark:to-gray-800/50">
           <div className="max-w-6xl mx-auto text-center">
-            <h1 className="text-4xl font-bold tracking-tight sm:text-6xl mb-6 leading-tight">
+            <h1 className="font-serif text-4xl font-bold tracking-tight sm:text-6xl mb-6 leading-tight">
               Built for fast capture.
               <span className="block text-teal-600 dark:text-teal-400">Focused by design.</span>
             </h1>
@@ -137,7 +137,7 @@ export default function FeaturesPage() {
         {/* CTA Section */}
         <section className="py-24 px-4 bg-gradient-to-br from-gray-50 via-white to-teal-50/30 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700">
           <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-6 leading-tight">
+            <h2 className="font-serif text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-6 leading-tight">
               Ready to capture more quickly?
             </h2>
             <p className="text-xl text-gray-600 dark:text-gray-300 mb-10 max-w-2xl mx-auto leading-relaxed">

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,11 +1,11 @@
-/* Google Fonts - Inter */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
-
 @import "tailwindcss";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 
-/* Apply Inter font to body */
 body {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.font-serif {
+  font-family: var(--font-display-serif), Georgia, Cambria, "Times New Roman", Times, serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,20 @@
 import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
+import { Inter, Source_Serif_4 } from "next/font/google";
 import type { ReactNode } from "react";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
+
+const displaySerif = Source_Serif_4({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-display-serif",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://usememos.com"),
@@ -149,7 +162,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
       </head>
-      <body className="flex flex-col min-h-screen antialiased">
+      <body className={`${inter.variable} ${displaySerif.variable} flex min-h-screen flex-col antialiased`}>
         <RootProvider>{children}</RootProvider>
       </body>
     </html>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -105,7 +105,7 @@ const LINKS = {
 const STYLES = {
   section: "mb-12 sm:mb-16 lg:mb-20",
   sectionHeader: "flex items-center justify-center gap-3 sm:gap-4 mb-8 sm:mb-10 lg:mb-12",
-  sectionTitle: "text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight",
+  sectionTitle: "font-serif text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight",
   iconContainer: "inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-xl",
   icon: "w-5 h-5 sm:w-6 sm:h-6",
   card: "bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-2xl sm:rounded-3xl shadow-lg",
@@ -134,7 +134,7 @@ export default function PricingPage() {
                   <DollarSignIcon className="w-10 h-10 sm:w-12 sm:h-12" />
                 </div>
               </div>
-              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl mb-4 sm:mb-6 leading-tight">Pricing</h1>
+              <h1 className="font-serif text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl mb-4 sm:mb-6 leading-tight">Pricing</h1>
               <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed px-4">
                 Free to use. Self-hosted by design.
               </p>
@@ -170,7 +170,7 @@ export default function PricingPage() {
             <section className={STYLES.section}>
               <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-blue-950 dark:via-indigo-950 dark:to-purple-950 border border-blue-200 dark:border-blue-800 rounded-2xl sm:rounded-3xl p-6 sm:p-8 lg:p-12 shadow-lg">
                 <div className="text-center">
-                  <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-blue-900 dark:text-blue-100 mb-4 sm:mb-6 tracking-tight">
+                  <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-blue-900 dark:text-blue-100 mb-4 sm:mb-6 tracking-tight">
                     Your Notes. Your Server. Your Rules.
                   </h2>
                   <p className="text-base sm:text-lg lg:text-xl text-blue-800 dark:text-blue-200 leading-relaxed max-w-3xl mx-auto">
@@ -369,7 +369,7 @@ export default function PricingPage() {
             ============================================================ */}
             <section className="text-center">
               <div className="bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 dark:from-teal-950 dark:via-cyan-950 dark:to-blue-950 border border-teal-200 dark:border-teal-800 rounded-2xl sm:rounded-3xl p-6 sm:p-8 lg:p-12 shadow-lg">
-                <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-teal-900 dark:text-teal-100 mb-3 sm:mb-4">
+                <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-teal-900 dark:text-teal-100 mb-3 sm:mb-4">
                   Start Capturing Thoughts
                 </h2>
                 <p className="text-base sm:text-lg lg:text-xl text-teal-800 dark:text-teal-200 mb-6 sm:mb-8 max-w-2xl mx-auto leading-relaxed">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -25,7 +25,7 @@ export default function PrivacyPage() {
                   <ShieldIcon className="w-12 h-12" />
                 </div>
               </div>
-              <h1 className="text-4xl font-bold tracking-tight sm:text-6xl mb-6 leading-tight">Privacy Policy</h1>
+              <h1 className="font-serif text-4xl font-bold tracking-tight sm:text-6xl mb-6 leading-tight">Privacy Policy</h1>
               <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed">
                 Privacy is part of the product. Memos is built so your data stays on infrastructure you control.
               </p>
@@ -35,7 +35,7 @@ export default function PrivacyPage() {
             <section className="mb-20">
               <div className="bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 dark:from-teal-950 dark:via-cyan-950 dark:to-blue-950 border border-teal-200 dark:border-teal-800 rounded-3xl p-12 shadow-lg">
                 <div className="text-center">
-                  <h2 className="text-3xl font-bold text-teal-900 dark:text-teal-100 mb-6 tracking-tight">The Simple Truth</h2>
+                  <h2 className="font-serif text-3xl font-bold text-teal-900 dark:text-teal-100 mb-6 tracking-tight">The Simple Truth</h2>
                   <p className="text-2xl text-teal-800 dark:text-teal-200 leading-relaxed mb-4">
                     We do not run tracking or analytics on you.
                   </p>
@@ -52,7 +52,7 @@ export default function PrivacyPage() {
                 <div className="inline-flex items-center justify-center w-12 h-12 bg-red-50 dark:bg-red-900/20 text-red-500 rounded-xl">
                   <EyeOffIcon className="w-6 h-6" />
                 </div>
-                <h2 className="text-3xl font-bold tracking-tight">Zero Data Collection</h2>
+                <h2 className="font-serif text-3xl font-bold tracking-tight">Zero Data Collection</h2>
               </div>
 
               <p className="text-center text-gray-600 dark:text-gray-400 mb-8 text-lg">
@@ -108,7 +108,7 @@ export default function PrivacyPage() {
                 <div className="inline-flex items-center justify-center w-12 h-12 bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 rounded-xl">
                   <ServerIcon className="w-6 h-6" />
                 </div>
-                <h2 className="text-3xl font-bold tracking-tight">Self-Hosted by Design</h2>
+                <h2 className="font-serif text-3xl font-bold tracking-tight">Self-Hosted by Design</h2>
               </div>
 
               <div className="bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-3xl p-12 shadow-lg mb-8">
@@ -171,7 +171,7 @@ export default function PrivacyPage() {
                 <div className="inline-flex items-center justify-center w-12 h-12 bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-xl">
                   <GithubIcon className="w-6 h-6" />
                 </div>
-                <h2 className="text-3xl font-bold tracking-tight">Open Source Transparency</h2>
+                <h2 className="font-serif text-3xl font-bold tracking-tight">Open Source Transparency</h2>
               </div>
 
               <div className="bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-3xl p-12 shadow-lg">
@@ -215,7 +215,7 @@ export default function PrivacyPage() {
                 <div className="inline-flex items-center justify-center w-12 h-12 bg-teal-50 dark:bg-teal-900/20 text-teal-600 dark:text-teal-400 rounded-xl">
                   <UsersIcon className="w-6 h-6" />
                 </div>
-                <h2 className="text-3xl font-bold tracking-tight">Questions?</h2>
+                <h2 className="font-serif text-3xl font-bold tracking-tight">Questions?</h2>
               </div>
 
               <div className="bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-3xl p-12 shadow-lg">

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -46,7 +46,9 @@ export default function SponsorsPage() {
                   <HeartIcon className="w-10 h-10 sm:w-12 sm:h-12 fill-current" />
                 </div>
               </div>
-              <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight px-4">Thanks!</h1>
+              <h1 className="font-serif text-3xl sm:text-4xl lg:text-6xl font-bold tracking-tight mb-4 sm:mb-6 leading-tight px-4">
+                Thanks!
+              </h1>
               <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed px-4">
                 All donations directly support the development and operation of Memos. Recurring donations allow us to plan for the future.
                 We deeply appreciate every donation — Thank you!
@@ -59,7 +61,7 @@ export default function SponsorsPage() {
                 <div className="inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 rounded-xl">
                   <span className="text-xl sm:text-2xl">🦄</span>
                 </div>
-                <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">Featured Sponsors</h2>
+                <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight">Featured Sponsors</h2>
               </div>
 
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8">
@@ -146,7 +148,7 @@ export default function SponsorsPage() {
                 <div className="inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 rounded-xl">
                   <span className="text-xl sm:text-2xl">🤠</span>
                 </div>
-                <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">Current Backers</h2>
+                <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight">Current Backers</h2>
               </div>
 
               <div className="flex flex-wrap justify-center gap-2 sm:gap-3">
@@ -199,7 +201,7 @@ export default function SponsorsPage() {
             {/* Support Options */}
             <section className="bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 dark:from-teal-950 dark:via-cyan-950 dark:to-blue-950 rounded-2xl sm:rounded-3xl p-6 sm:p-10 lg:p-16 shadow-lg">
               <div className="text-center">
-                <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4 sm:mb-6 px-4">Support Memos Development</h2>
+                <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-4 sm:mb-6 px-4">Support Memos Development</h2>
                 <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 mb-8 sm:mb-10 max-w-2xl mx-auto leading-relaxed px-4">
                   Your support helps us maintain and improve Memos for everyone. Choose how you&apos;d like to contribute to our open-source
                   mission.
@@ -232,7 +234,7 @@ export default function SponsorsPage() {
             {/* Thank You Message */}
             <section className="mt-12 sm:mt-16 lg:mt-20 text-center px-4">
               <div className="max-w-2xl mx-auto">
-                <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4 sm:mb-6">Every Contribution Matters</h2>
+                <h2 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight mb-4 sm:mb-6">Every Contribution Matters</h2>
                 <p className="text-base sm:text-lg lg:text-xl text-gray-600 dark:text-gray-300 leading-relaxed">
                   Whether you&apos;re contributing code, reporting bugs, writing documentation, or providing financial support, you&apos;re
                   helping make Memos better for everyone. Our community is what makes this project special.

--- a/src/app/use-cases/[slug]/page.tsx
+++ b/src/app/use-cases/[slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
               >
                 <IconComponent className="w-8 h-8 sm:w-10 sm:h-10" />
               </div>
-              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight">
+              <h1 className="font-serif text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4 sm:mb-6 leading-tight">
                 {useCase.title}
               </h1>
               <p className="text-lg sm:text-xl lg:text-2xl text-gray-600 dark:text-gray-400 mb-8 max-w-3xl mx-auto leading-relaxed">
@@ -116,7 +116,7 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 sm:gap-12">
                 {/* Common Workflows */}
                 <div>
-                  <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 flex items-center gap-3">
+                  <h2 className="font-serif text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 flex items-center gap-3">
                     <div className="inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-xl">
                       <ZapIcon className="w-5 h-5 sm:w-6 sm:h-6 text-teal-600 dark:text-teal-400" />
                     </div>
@@ -134,7 +134,7 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
 
                 {/* Why Memos */}
                 <div>
-                  <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 flex items-center gap-3">
+                  <h2 className="font-serif text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 flex items-center gap-3">
                     <div className="inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-xl">
                       <HeartPulseIcon className="w-5 h-5 sm:w-6 sm:h-6 text-cyan-600 dark:text-cyan-400" />
                     </div>
@@ -154,7 +154,7 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
 
             {/* Related Features */}
             <div className="mb-12 sm:mb-16">
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 text-center">
+              <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-6 sm:mb-8 text-center">
                 Key Features for This Use Case
               </h2>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
@@ -175,7 +175,7 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
 
             {/* CTA Section */}
             <div className="bg-gradient-to-br from-teal-50 via-cyan-50/50 to-gray-50 dark:from-gray-800 dark:via-gray-800 dark:to-gray-700 border border-teal-100 dark:border-gray-600 rounded-2xl sm:rounded-3xl p-8 sm:p-12 lg:p-16 shadow-xl text-center">
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4 sm:mb-6">
+              <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4 sm:mb-6">
                 Ready to get started?
               </h2>
               <p className="text-base sm:text-lg text-gray-700 dark:text-gray-300 mb-8 sm:mb-10 max-w-2xl mx-auto leading-relaxed">

--- a/src/app/use-cases/page.tsx
+++ b/src/app/use-cases/page.tsx
@@ -138,7 +138,7 @@ export default function UseCasesPage() {
             <div className="inline-flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl sm:rounded-3xl mb-6 sm:mb-8">
               <LightbulbIcon className="w-8 h-8 sm:w-10 sm:h-10" />
             </div>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 leading-tight">
+            <h1 className="font-serif text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 leading-tight">
               How People Use Memos
             </h1>
             <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto leading-relaxed mb-8">
@@ -178,7 +178,7 @@ export default function UseCasesPage() {
                         <IconComponent className="w-7 h-7 sm:w-8 sm:h-8" />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors">
+                        <h2 className="font-serif text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2 group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors">
                           {useCase.title}
                         </h2>
                         <p className="text-base sm:text-lg text-gray-700 dark:text-gray-300 font-medium">{useCase.subtitle}</p>
@@ -204,7 +204,7 @@ export default function UseCasesPage() {
         <section className="py-12 sm:py-16 lg:py-24 px-4 bg-gradient-to-b from-gray-50/50 to-white dark:from-gray-800/50 dark:to-gray-900">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12 sm:mb-16">
-              <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4">
+              <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-4">
                 Find Your Use Case
               </h2>
               <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
@@ -236,7 +236,7 @@ export default function UseCasesPage() {
             <div className="inline-flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-teal-100 to-cyan-100 dark:from-teal-900/30 dark:to-cyan-900/30 text-teal-600 dark:text-teal-400 rounded-2xl mb-6">
               <UserIcon className="w-8 h-8 sm:w-10 sm:h-10" />
             </div>
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 leading-tight">
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 leading-tight">
               Ready to start your own use case?
             </h2>
             <p className="text-base sm:text-lg text-gray-700 dark:text-gray-300 mb-10 max-w-2xl mx-auto leading-relaxed">

--- a/src/components/changelog-header.tsx
+++ b/src/components/changelog-header.tsx
@@ -20,7 +20,9 @@ export function ChangelogHeader({ version, date, isLatest = false, breaking = fa
         {isLatest && <span className="px-3 py-1.5 bg-teal-600 text-white text-xs font-semibold rounded-full">Latest Release</span>}
       </div>
 
-      <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-4 leading-tight">{version}</h1>
+      <h1 className="font-serif text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-4 leading-tight">
+        {version}
+      </h1>
 
       {date && (
         <div className="flex flex-wrap items-center gap-4 text-gray-600 dark:text-gray-300 mb-6">

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -60,7 +60,7 @@ export function HeroSection({
               </div>
             )}
 
-            <h1 className="max-w-4xl text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight text-gray-900 dark:text-gray-50">
+            <h1 className="max-w-4xl font-serif text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight text-gray-900 dark:text-gray-50">
               {title}
             </h1>
 

--- a/src/components/sponsors-section.tsx
+++ b/src/components/sponsors-section.tsx
@@ -11,7 +11,9 @@ export function SponsorsSection() {
         <div className="text-center mb-8 sm:mb-10 lg:mb-12">
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 mb-4">
             <HeartIcon className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 text-red-500 fill-current shrink-0" />
-            <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Supported by</h2>
+            <h2 className="font-serif text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+              Supported by
+            </h2>
           </div>
           <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
             Thanks to the sponsors who help keep Memos moving.


### PR DESCRIPTION
## Summary
- apply `font-serif` to prominent page and section headings across the marketing site
- switch font loading to `next/font` for Inter body text and a serif display face for headings
- map serif heading styles in global CSS so display typography renders consistently

## Testing
- Not run (not requested)