### PR TITLE
fix(theme): align hero and nav styling with Fumadocs tokens

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -72,7 +72,7 @@ export default function HomePage() {
         title={
           <>
             Capture freely.
-            <span className="block text-teal-600 dark:text-teal-400">Own completely.</span>
+            <span className="block text-fd-primary">Own completely.</span>
           </>
         }
         subtitle="A private timeline for your thoughts. Self-hosted, Markdown-native, and built to stay out of your way."

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -2,8 +2,65 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 
+:root {
+  --background: oklch(0.9818 0.0054 95.0986);
+  --foreground: oklch(0.2438 0.0269 95.7226);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.1908 0.002 106.5859);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2671 0.0196 98.939);
+  --primary: oklch(0.45 0.08 250);
+  --primary-foreground: oklch(0.9818 0.0054 95.0986);
+  --secondary: oklch(0.9245 0.0138 92.9892);
+  --secondary-foreground: oklch(0.4334 0.0177 98.6048);
+  --muted: oklch(0.9341 0.0153 90.239);
+  --muted-foreground: oklch(0.5559 0.0075 97.4233);
+  --accent: oklch(0.9245 0.0138 92.9892);
+  --accent-foreground: oklch(0.2671 0.0196 98.939);
+  --border: oklch(0.8847 0.0069 97.3627);
+  --ring: oklch(0.45 0.08 250);
+
+  --color-fd-background: var(--background);
+  --color-fd-foreground: var(--foreground);
+  --color-fd-muted: var(--muted);
+  --color-fd-muted-foreground: var(--muted-foreground);
+  --color-fd-popover: var(--popover);
+  --color-fd-popover-foreground: var(--popover-foreground);
+  --color-fd-card: var(--card);
+  --color-fd-card-foreground: var(--card-foreground);
+  --color-fd-border: var(--border);
+  --color-fd-primary: var(--primary);
+  --color-fd-primary-foreground: var(--primary-foreground);
+  --color-fd-secondary: var(--secondary);
+  --color-fd-secondary-foreground: var(--secondary-foreground);
+  --color-fd-accent: var(--accent);
+  --color-fd-accent-foreground: var(--accent-foreground);
+  --color-fd-ring: var(--ring);
+}
+
+.dark {
+  --background: hsl(0, 0%, 7.04%);
+  --foreground: hsl(0, 0%, 92%);
+  --card: hsl(0, 0%, 9.8%);
+  --card-foreground: hsl(0, 0%, 98%);
+  --popover: hsl(0, 0%, 11.6%);
+  --popover-foreground: hsl(0, 0%, 86.9%);
+  --primary: hsl(0, 0%, 98%);
+  --primary-foreground: hsl(0, 0%, 9%);
+  --secondary: hsl(0, 0%, 12.9%);
+  --secondary-foreground: hsl(0, 0%, 92%);
+  --muted: hsl(0, 0%, 12.9%);
+  --muted-foreground: hsla(0, 0%, 70%, 0.8);
+  --accent: hsla(0, 0%, 40.9%, 30%);
+  --accent-foreground: hsl(0, 0%, 90%);
+  --border: hsla(0, 0%, 40%, 20%);
+  --ring: hsl(0, 0%, 54.9%);
+}
+
 body {
   font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background-color: var(--color-fd-background);
+  color: var(--color-fd-foreground);
 }
 
 .font-serif {

--- a/src/app/layout.config.tsx
+++ b/src/app/layout.config.tsx
@@ -19,15 +19,15 @@ export const baseOptions: BaseLayoutProps = {
   },
   links: [
     {
-      text: "Documentation",
+      text: <span className="font-semibold">Documentation</span>,
       url: "/docs",
     },
     {
-      text: "Changelog",
+      text: <span className="font-semibold">Changelog</span>,
       url: "/changelog",
     },
     {
-      text: "Features",
+      text: <span className="font-semibold">Features</span>,
       url: "/features",
     },
   ],

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -38,11 +38,8 @@ export function HeroSection({
   return (
     <section className="relative px-4 sm:px-6 lg:px-4 pt-6 sm:pt-8 pb-12 overflow-hidden">
       {/* Main hero card */}
-      <div className="relative max-w-(--fd-layout-width) mx-auto rounded-3xl sm:rounded-[2rem] bg-gradient-to-br from-teal-50 via-cyan-50/60 to-amber-50/30 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 overflow-hidden">
-        {/* Decorative gradient orbs */}
-        <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-gradient-to-bl from-teal-200/40 via-cyan-200/20 to-transparent dark:from-teal-800/20 dark:via-cyan-800/10 rounded-full blur-3xl pointer-events-none" />
-        <div className="absolute bottom-0 left-1/4 w-[400px] h-[400px] bg-gradient-to-tr from-amber-100/30 via-teal-100/20 to-transparent dark:from-amber-900/10 dark:via-teal-900/10 rounded-full blur-3xl pointer-events-none" />
-
+      <div className="relative mx-auto max-w-(--fd-layout-width) overflow-hidden rounded-3xl border border-fd-border bg-fd-card shadow-sm shadow-black/5 sm:rounded-[2rem]">
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-white/55 to-transparent dark:from-white/5" />
         <div className="relative z-10">
           {/* Text content - left aligned */}
           <div className="px-6 sm:px-10 lg:px-16 pt-10 sm:pt-14 lg:pt-20 pb-8 sm:pb-10 lg:pb-14">
@@ -50,7 +47,7 @@ export function HeroSection({
               <div className="mb-6 sm:mb-8">
                 <Link
                   href={`/changelog/${version.replace(/\./g, "-")}`}
-                  className="inline-flex items-center gap-2 px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-teal-700 dark:text-teal-300 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-teal-200/60 dark:border-teal-700/60 rounded-full hover:bg-white/80 dark:hover:bg-gray-800/80 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300"
+                  className="inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-popover px-3 py-1.5 text-xs font-medium text-fd-primary shadow-sm shadow-black/5 transition-all duration-300 hover:-translate-y-0.5 hover:bg-fd-secondary hover:shadow-md sm:px-4 sm:py-2 sm:text-sm"
                 >
                   <SparklesIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                   <span className="opacity-70">Released</span>
@@ -60,18 +57,18 @@ export function HeroSection({
               </div>
             )}
 
-            <h1 className="max-w-4xl font-serif text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight text-gray-900 dark:text-gray-50">
+            <h1 className="max-w-4xl font-serif text-4xl font-bold tracking-tight text-fd-foreground sm:text-5xl md:text-6xl lg:text-7xl">
               {title}
             </h1>
 
-            <p className="mt-5 sm:mt-6 max-w-lg text-lg sm:text-xl lg:text-2xl text-gray-500 dark:text-gray-400 leading-relaxed">
+            <p className="mt-5 max-w-lg text-lg leading-relaxed text-fd-muted-foreground sm:mt-6 sm:text-xl lg:text-2xl">
               {subtitle}
             </p>
 
-            <div className="mt-8 sm:mt-10 flex flex-row gap-3 sm:gap-4">
+            <div className="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:gap-4">
               <Link
                 href={primaryCta.href}
-                className="group inline-flex items-center justify-center gap-2 px-5 py-3 sm:px-7 sm:py-3.5 text-sm sm:text-base font-semibold text-white bg-teal-600 dark:bg-teal-500 rounded-full shadow-lg shadow-teal-600/20 hover:bg-teal-700 dark:hover:bg-teal-400 hover:shadow-xl hover:shadow-teal-600/30 hover:-translate-y-0.5 transition-all duration-300"
+                className="group inline-flex w-full items-center justify-center gap-2 rounded-full bg-fd-primary px-5 py-3 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-[color:oklch(0.45_0.08_250_/_0.22)] transition-all duration-300 hover:-translate-y-0.5 hover:opacity-90 hover:shadow-xl hover:shadow-[color:oklch(0.45_0.08_250_/_0.28)] sm:w-auto sm:px-7 sm:py-3.5 sm:text-base"
               >
                 {primaryCta.text}
               </Link>
@@ -79,7 +76,7 @@ export function HeroSection({
                 href={secondaryCta.href}
                 target={secondaryCta.external ? "_blank" : undefined}
                 rel={secondaryCta.external ? "noopener noreferrer" : undefined}
-                className="group inline-flex items-center justify-center gap-2 px-5 py-3 sm:px-7 sm:py-3.5 text-sm sm:text-base font-semibold text-gray-700 dark:text-gray-200 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border border-gray-200/80 dark:border-gray-600/80 rounded-full hover:bg-white dark:hover:bg-gray-700 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300"
+                className="group inline-flex w-full items-center justify-center gap-2 rounded-full border border-fd-border bg-fd-popover px-5 py-3 text-sm font-semibold text-fd-foreground shadow-sm shadow-black/5 transition-all duration-300 hover:-translate-y-0.5 hover:bg-fd-secondary hover:shadow-lg sm:w-auto sm:px-7 sm:py-3.5 sm:text-base"
               >
                 {secondaryCta.text}
                 <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
@@ -89,9 +86,9 @@ export function HeroSection({
 
           {/* Demo image - use a focused crop on mobile and the wide preview on desktop */}
           {(demoImageLight || demoImageDark) && (
-            <div className="px-0 md:px-0 pb-4 sm:pb-0">
+            <div className="border-t border-fd-border bg-fd-background px-0 pb-4 sm:pb-0 md:px-0">
               <div className="relative mr-auto overflow-hidden md:hidden">
-                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-14 bg-gradient-to-b from-white/75 via-white/20 to-transparent dark:from-gray-950/70 dark:via-gray-950/10" />
+                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-14 bg-gradient-to-b from-[color:oklch(1_0_0_/_0.78)] via-[color:oklch(1_0_0_/_0.18)] to-transparent dark:from-gray-950/70 dark:via-gray-950/10" />
                 {demoImageLight && (
                   <div className="relative aspect-[11/10] dark:hidden">
                     <Image


### PR DESCRIPTION
## Summary
- centralize the site theme around Memos light and dark tokens in `global.css`
- map Fumadocs color variables to those tokens so shared layout chrome follows the same palette
- refresh the home hero to use token-based surfaces, simplified card styling, and stronger CTA hierarchy
- make the home nav link labels semibold and switch the hero accent text to `fd` theme colors

## Testing
- `pnpm exec tsc --noEmit`