### PR TITLE
Detect system dark mode preference and apply it by default

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -163,7 +163,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
       </head>
       <body className={`${inter.variable} ${displaySerif.variable} flex min-h-screen flex-col antialiased`}>
-        <RootProvider>{children}</RootProvider>
+        <RootProvider theme={{ defaultTheme: "system", enableSystem: true }}>{children}</RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Set defaultTheme to "system" with enableSystem on RootProvider so users
with OS-level dark mode preference are no longer shown the light theme.

https://claude.ai/code/session_01U8cJSR7bEbqLA3CsWSzRtv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * App theme now automatically follows your system's light or dark mode preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->