### PR TITLE
Add the "AI Clients" integration docs.

### DIFF
--- a/content/docs/integrations/ai.mdx
+++ b/content/docs/integrations/ai.mdx
@@ -1,0 +1,106 @@
+---
+title: AI
+description: Connecting AI clients to Memos.
+---
+
+There are two main ways of enabling AI clients to work with your Memos
+instance: using MCP or using the API directly.
+
+## MCP
+
+Memos exposes much of its functionality through an embedded MCP server at `/mcp`.
+
+First, you will need an API token as described in the [authentication docs](../api/latest#authentication).
+
+The exact next steps to configure the MCP server will be different for each AI
+client. Taking OpenCode as an example, just make sure that the memos MCP server
+is properly declared in your `~/.config/opencode/opencode.json`, like this:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "memos": {
+      "type": "remote",
+      "url": "http://localhost:5230/mcp",
+      "headers": {
+        "Authorization": "Bearer <your_token>"
+      }
+    }
+  }
+}
+```                                
+
+(Do not forget to replace the URL and token with actual values.)
+
+
+## Direct API access
+
+In some situations, you may want to give agents direct API access instead. One
+possible way of doing that is by using an agentic tool called Latchkey.
+
+
+### 1. Install the prerequisites
+
+Install Latchkey on the machine where the agent will run. That
+will allow the agent to send authenticated HTTP requests to the
+API without leaking any secrets into prompts.
+
+1. Make sure your system has a working `node` installation. If not, you can download it from the [official page](https://nodejs.org/en/download).
+2. Install Latchkey:
+
+    ```bash
+    npm install -g latchkey
+    ```
+
+### 2. Generate and Configure the API Token
+
+1. Get an API token as described in the [authentication docs](../api/latest#authentication).
+2. Point Latchkey to your Memos instance, for example:
+
+    ```bash
+    latchkey services register memos \
+        --base-api-url=http://localhost:5230/api/v1
+    ```
+
+3. Insert the API token:
+
+    ```bash
+    latchkey auth set memos -H "Authorization: Bearer <your_token>"
+    ```
+
+### 3. Configure the AI Agent
+
+Using `skills.sh`:
+
+```bash
+npx skills add imbue-ai/latchkey
+```
+
+You can also configure the AI agent manually. The exact steps
+will differ depending on the agent. Taking OpenCode as an example:
+
+```bash
+mkdir -p ~/.opencode/skills/latchkey
+latchkey skill-md > ~/.opencode/skills/latchkey/SKILL.md
+```
+
+## Using the AI client
+
+After completing the previous steps, you should now be able to
+use your AI client of choice to work with Memos! Here are some
+example questions and tasks for an AI agent:
+
+> I had a note about fixing that issue where my terminal freezes - what was the fix?
+
+or
+
+> Find memos that have incomplete task lists.
+
+or even
+
+> Here's an article about agentic authorization and credential management.
+Summarize it, create a memo with the key takeaways, and link it to my existing
+memos on AI tooling.
+
+From here, it's up to your imagination.

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -15,4 +15,7 @@ Memos includes a small set of built-in integrations and supports community proje
   <Card title="Telegram Bot" href="/docs/integrations/telegram-bot" icon="MessageCircle">
     Community integration for Telegram.
   </Card>
+  <Card title="AI" href="/docs/integrations/ai" icon="BotMessageSquare">
+    Connect AI Clients.
+  </Card>
 </Cards>

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Integrations",
   "description": "Connect Memos with third-party services and tools",
-  "pages": ["index", "rss", "telegram-bot", "webhooks"]
+  "pages": ["index", "rss", "telegram-bot", "webhooks", "ai"]
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,5 +1,6 @@
 import {
   ActivityIcon,
+  BotMessageSquareIcon,
   AlertTriangleIcon,
   ArrowRightIcon,
   ArrowUpIcon,
@@ -94,6 +95,7 @@ const iconMap: Record<string, LucideIcon> = {
   Puzzle: PuzzleIcon,
   Terminal: TerminalIcon,
   Rss: RssIcon,
+  BotMessageSquare: BotMessageSquareIcon,
 };
 
 interface CardsProps {


### PR DESCRIPTION
This PR adds a simple guide for connecting AI clients to Memos.

I believe that it's worth pointing out the option of doing so because of the strong use cases: from AI agents helping to retrieve your notes, to agents using them as guidance for their own actions, all the way to AI agents actively building a knowledge base (similar to e.g. this: https://x.com/karpathy/status/2039805659525644595).

The PR describes both using the embedded `/mcp` server as well as an alternative in the form of a direct API access. That could be achieved in various ways. The one that's been chosen here is relatively straightforward, secure (secrets are encrypted, the agents don't see them, and no intermediaries or third parties get to see them either), general (the same setup can be used for any AI agent and even reused for other APIs), and friendly to local setups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new AI integrations documentation covering two connection methods: using an embedded MCP server and direct API access via Latchkey.
  * Added AI integrations card to the integrations overview page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->